### PR TITLE
Removed redundant database name

### DIFF
--- a/ebook/en/content/003-creating-tables.md
+++ b/ebook/en/content/003-creating-tables.md
@@ -72,7 +72,7 @@ Alternatively, if you do not want to 'switch' to the specific database, you woul
 
 ```
 USE demo_db;
-SELECT username FROM demo_db.users;
+SELECT username FROM users;
 ```
 
 * Alternatively, rather than using the `USE` command first, specify the database name followed by the table name separated with a  dot: `db_name.table_name`:


### PR DESCRIPTION
The database name is redundant after using the USE query.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/bobbyiliev/introduction-to-sql/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [x] 📝 Documentation Update
- [ ] 🚩 Other

## Description
the database name is not necessary after using USE keyword.


## Related Tickets & Documents



## Added to documentation?

- [ ] 📜 readme
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?